### PR TITLE
GRIS-32. Refactor db access

### DIFF
--- a/graph_api/database_service.py
+++ b/graph_api/database_service.py
@@ -1,0 +1,100 @@
+import string
+import requests
+from requests.auth import HTTPBasicAuth
+from database_config import database
+
+
+class DatabaseService:
+    """
+    Object that handles communication with Neo4j database
+
+    Attributes:
+        database_url (str): Database URL 
+        database_auth (HTTPBasicAuth): Database connection credentials
+        check_node_template (string.Template): Template for checking the node
+        create_node_template (string.Template): Template for creating the node
+        create_relationship_template (string.Template): Template for creating the relationship
+        _instance (DatabaseService): Instance of the singleton object
+    """
+    database_url = (database["address"] + database["commit_path"]) \
+        .replace("{database_name}", database["name"])
+    database_auth = HTTPBasicAuth(database["user"], database["passwd"])
+
+    check_node_template = string.Template(
+        "MATCH (n) where id(n) =$node_id return n")
+    create_node_template = string.Template("CREATE (n:$labels) RETURN n")
+    create_relationship_template = string.Template("MATCH (n) where id(n) =$start_node MATCH (m) where id(m) = "
+                                                   "$end_node MERGE (n) - [r:$name] -> (m) RETURN r")
+
+    _instance = None
+
+    def __new__(cls):
+        """
+        Creates singleton
+        """
+        if cls._instance is None:
+            cls._instance = super(DatabaseService, cls).__new__(cls)
+        return cls._instance
+
+    def post(self, statement):
+        """
+        Send request to database by its API
+
+        Args:
+            statement (string): Statement to be sent
+
+        Returns:
+            Result of request      
+        """
+        commit_body = {
+            "statements": [{"statement": statement}]
+        }
+        response = requests.post(url=self.database_url,
+                                 json=commit_body,
+                                 auth=self.database_auth).json()
+        return response
+
+    def node_exists(self, node_id):
+        """
+        Check wheather node with given id exists
+
+        Args:
+            node_id (int): node id to be checked
+
+        Returns:
+            True if exists, otherwise false 
+        """
+        check_node_statement = self.check_node_template.substitute(
+            node_id=node_id)
+        response = self.post(check_node_statement)
+        return len(response['results']) != 0 and len(response['results'][0]['data']) == 1
+
+    def create_node(self, node):
+        """
+        Send to the database request to create node
+
+        Args:
+            node (): node to be created
+
+        Returns:
+            Result of request      
+        """
+        create_statement = self.create_node_template.substitute(
+            labels=":".join(list(node.labels))
+        )
+        return self.post(create_statement)
+
+    def create_relationship(self, relationship):
+        """
+        Send to the database request to create relationship
+
+        Args:
+            relationship (): relationship to be created
+
+        Returns:
+            Result of request      
+        """
+        create_statement = self.create_relationship_template.substitute(start_node=relationship.start_node,
+                                                                        end_node=relationship.end_node,
+                                                                        name=relationship.name)
+        return self.post(create_statement)

--- a/graph_api/node/node_service.py
+++ b/graph_api/node/node_service.py
@@ -1,3 +1,4 @@
+import requests
 from database_service import DatabaseService
 from node.node_model import NodeIn, NodeOut
 from property.property_model import PropertyIn

--- a/graph_api/node/node_service.py
+++ b/graph_api/node/node_service.py
@@ -1,11 +1,4 @@
-import requests
-<<<<<<< HEAD
 from database_service import DatabaseService
-=======
-import string
-from requests.auth import HTTPBasicAuth
-from database_config import database
->>>>>>> 5026709... GRIS-25. Implementation of property model and development of node service and … (#17)
 from node.node_model import NodeIn, NodeOut
 from property.property_model import PropertyIn
 from typing import List
@@ -19,29 +12,7 @@ class NodeService:
         db (DatabaseService): Handles communication with Neo4j database
     """
 
-    db = DatabaseService()
-
-    def node_exists(self, node_id):
-        """
-        Check if node exists in the database
-
-        Args:
-            node_id(int): id of the node
-
-        Returns:
-            True - If there is a node in the database.
-            False - If there is not a node in the database.
-        """
-        check_node_statement = f"MATCH (n) where id(n) ={node_id} return n"
-
-        commit_body = {
-            "statements": [{"statement": check_node_statement}]
-        }
-        response = requests.post(url=self.database_url,
-                                 json=commit_body,
-                                 auth=self.database_auth).json()
-
-        return len(response['results'][0]['data']) == 1
+    db : DatabaseService = DatabaseService()
 
     def save_node(self, node: NodeIn):
         """
@@ -75,19 +46,8 @@ class NodeService:
         Returns:
             Result of request as node object
         """
-        if self.node_exists(id):
-            create_statement = f"MATCH (n) where id(n)={id} SET n = $props return n"
-            commit_body = {
-                "statements": [{"statement": create_statement,
-                                "parameters": {
-                                    "props": {
-                                        property.key: property.value for property in properties
-                                    }
-                                }}]
-            }
-            response = requests.post(url=self.database_url,
-                                     json=commit_body,
-                                     auth=self.database_auth).json()
+        if self.db.node_exists(id):
+            response = self.db.create_properties(id, properties)
             if len(response["errors"]) > 0:
                 result = NodeOut(errors=response["errors"])
             else:

--- a/graph_api/node/node_service.py
+++ b/graph_api/node/node_service.py
@@ -1,5 +1,11 @@
 import requests
+<<<<<<< HEAD
 from database_service import DatabaseService
+=======
+import string
+from requests.auth import HTTPBasicAuth
+from database_config import database
+>>>>>>> 5026709... GRIS-25. Implementation of property model and development of node service and … (#17)
 from node.node_model import NodeIn, NodeOut
 from property.property_model import PropertyIn
 from typing import List

--- a/graph_api/relationship/relationship_model.py
+++ b/graph_api/relationship/relationship_model.py
@@ -27,6 +27,7 @@ class RelationshipOut(RelationshipIn):
             propeties(Optional[List[PropertyIn]]): List of properties of the relationship in the database
             errors (Optional[Any]): Optional errors appeared during query executions
     """
+
     id: Optional[int]
     properties: Optional[List[PropertyIn]] = None
     errors: Optional[Any] = None

--- a/graph_api/relationship/relationship_model.py
+++ b/graph_api/relationship/relationship_model.py
@@ -27,7 +27,6 @@ class RelationshipOut(RelationshipIn):
             propeties(Optional[List[PropertyIn]]): List of properties of the relationship in the database
             errors (Optional[Any]): Optional errors appeared during query executions
     """
-
     id: Optional[int]
     properties: Optional[List[PropertyIn]] = None
     errors: Optional[Any] = None

--- a/graph_api/relationship/relationship_service.py
+++ b/graph_api/relationship/relationship_service.py
@@ -89,6 +89,7 @@ class RelationshipService:
         else:
             result = RelationshipOut(start_node=relationship.start_node, end_node=relationship.end_node,
                                      name=relationship.name, errors={"errors": "not matching id"})
+
         return result
 
     def save_properties(self, id: int, properties: List[PropertyIn]):

--- a/graph_api/relationship/relationship_service.py
+++ b/graph_api/relationship/relationship_service.py
@@ -5,7 +5,6 @@ from relationship.relationship_model import RelationshipOut, RelationshipIn
 from property.property_model import PropertyIn
 from typing import List
 
-
 class RelationshipService:
     """
     Object to handle logic of relationships requests
@@ -90,7 +89,6 @@ class RelationshipService:
         else:
             result = RelationshipOut(start_node=relationship.start_node, end_node=relationship.end_node,
                                      name=relationship.name, errors={"errors": "not matching id"})
-
         return result
 
     def save_properties(self, id: int, properties: List[PropertyIn]):
@@ -128,4 +126,5 @@ class RelationshipService:
 
         return result
     
+
 

--- a/graph_api/relationship/relationship_service.py
+++ b/graph_api/relationship/relationship_service.py
@@ -128,3 +128,4 @@ class RelationshipService:
 
         return result
     
+

--- a/graph_api/relationship/relationship_service.py
+++ b/graph_api/relationship/relationship_service.py
@@ -1,3 +1,4 @@
+import requests
 from database_service import DatabaseService
 from database_config import database
 from relationship.relationship_model import RelationshipOut, RelationshipIn

--- a/graph_api/relationship/relationship_service.py
+++ b/graph_api/relationship/relationship_service.py
@@ -1,64 +1,19 @@
-import requests
-from requests.auth import HTTPBasicAuth
+from database_service import DatabaseService
 from database_config import database
 from relationship.relationship_model import RelationshipOut, RelationshipIn
 from property.property_model import PropertyIn
 from typing import List
+
 
 class RelationshipService:
     """
     Object to handle logic of relationships requests
 
     Attributes:
-        database_url (str): URL to used database
-        database_auth (HTTPBasicAuth): Used to authenticate to database
+        db (DatabaseService): Handles communication with Neo4j database
     """
-    database_url = (database["address"] + database["commit_path"]) \
-        .replace("{database_name}", database["name"])
-    database_auth = HTTPBasicAuth(database["user"], database["passwd"])
 
-    def node_exists(self, node_id):
-        """
-        Check if node exists in the database
-        
-        Args:
-            node_id(int): id of the node
-            
-        Returns:
-            True - If there is a node in the database.
-            False - If there is not a node in the database.
-        """
-        check_node_statement = f"MATCH (n) where id(n) ={node_id} return n"
-
-        commit_body = {
-            "statements": [{"statement": check_node_statement}]
-        }
-        response = requests.post(url=self.database_url,
-                                 json=commit_body,
-                                 auth=self.database_auth).json()
-
-        return len(response['results'][0]['data']) == 1
-
-    def relationship_exist(self, relationship_id):
-        """
-        Check if relationship exists in the database
-
-        Args:
-            relationship_id(int): id of the relationship
-
-        Returns:
-            True - If there is a relationship in the database.
-            False - If there is not a relationship in the database.
-        """
-        check_relationship_statement = f"MATCH ()-[r]->() where id(r) ={relationship_id} return r"
-        commit_body = {
-            "statements": [{"statement": check_relationship_statement}]
-        }
-        response = requests.post(url=self.database_url,
-                                 json=commit_body,
-                                 auth=self.database_auth).json()
-
-        return len(response['results'][0]['data']) == 1
+    db = DatabaseService()
 
     def save_relationship(self, relationship: RelationshipIn):
         """
@@ -70,14 +25,8 @@ class RelationshipService:
         Returns:
             Result of request as relationship object
         """
-        if self.node_exists(relationship.start_node) and self.node_exists(relationship.end_node):
-            create_statement = f"MATCH (n) where id(n) ={relationship.start_node} MATCH (m) where id(m) = {relationship.end_node} MERGE (n) - [r:{relationship.name}] -> (m) RETURN r"
-            commit_body = {
-                "statements": [{"statement": create_statement}]
-            }
-            response = requests.post(url=self.database_url,
-                                     json=commit_body,
-                                     auth=self.database_auth).json()
+        if self.db.node_exists(relationship.start_node) and self.db.node_exists(relationship.end_node):
+            response = self.db.create_relationship(relationship)
 
             if len(response["errors"]) > 0:
                 result = RelationshipOut(start_node=relationship.start_node, end_node=relationship.end_node,
@@ -88,7 +37,7 @@ class RelationshipService:
                                          name=relationship.name, id=relationship_id)
         else:
             result = RelationshipOut(start_node=relationship.start_node, end_node=relationship.end_node,
-                                     name=relationship.name, errors={"errors": "not matching id"})
+                                     name=relationship.name, errors={"errors": "not matching node id"})
 
         return result
 

--- a/graph_api/relationship/relationship_service.py
+++ b/graph_api/relationship/relationship_service.py
@@ -1,4 +1,3 @@
-import requests
 from database_service import DatabaseService
 from database_config import database
 from relationship.relationship_model import RelationshipOut, RelationshipIn
@@ -13,8 +12,7 @@ class RelationshipService:
     Attributes:
         db (DatabaseService): Handles communication with Neo4j database
     """
-
-    db = DatabaseService()
+    db: DatabaseService = DatabaseService()
 
     def save_relationship(self, relationship: RelationshipIn):
         """
@@ -54,19 +52,9 @@ class RelationshipService:
         Returns:
             Result of request as relationship object
         """
-        if self.relationship_exist(id):
-            create_statement = f"MATCH ()-[r]->() where id(r)={id} set r = $props return r"
-            commit_body = {
-                "statements": [{"statement": create_statement,
-                                "parameters": {
-                                    "props": {
-                                        property.key: property.value for property in properties
-                                    }
-                                }}]
-            }
-            response = requests.post(url=self.database_url,
-                                     json=commit_body,
-                                     auth=self.database_auth).json()
+        if self.db.relationship_exist(id):
+            response = self.db.create_properties(id, properties)
+
             if len(response["errors"]) > 0:
                 result = RelationshipOut(errors=response["errors"])
             else:

--- a/graph_api/tests/test_node_service.py
+++ b/graph_api/tests/test_node_service.py
@@ -8,7 +8,7 @@ import json
 
 class TestNodePostService(unittest.TestCase):
 
-    @mock.patch('node.node_service.requests')
+    @mock.patch('database_service.requests')
     def test_node_service_without_error(self, mock_requests):
         response = Response()
         response._content = json.dumps({'results': [
@@ -26,7 +26,7 @@ class TestNodePostService(unittest.TestCase):
 
         self.assertEqual(result, NodeOut(id=5, labels={"test"}, errors=None))
 
-    @mock.patch('node.node_service.requests')
+    @mock.patch('database_service.requests')
     def test_node_service_with_error(self, mock_requests):
         response = Response()
         response._content = json.dumps({'results': [{'data': [{'meta': [{}]}]}],

--- a/graph_api/tests/test_property_node_service.py
+++ b/graph_api/tests/test_property_node_service.py
@@ -8,7 +8,7 @@ import json
 
 class TestNodePostService(unittest.TestCase):
 
-    @mock.patch('node.node_service.requests')
+    @mock.patch('database_service.requests')
     def test_node_service_without_error(self, mock_requests):
         response = Response()
         response._content = json.dumps({'results': [
@@ -25,7 +25,7 @@ class TestNodePostService(unittest.TestCase):
 
         self.assertEqual(result, NodeOut(id=5, properties=properties, errors=None))
 
-    @mock.patch('node.node_service.requests')
+    @mock.patch('database_service.requests')
     def test_node_service_with_error(self, mock_requests):
         response = Response()
         response._content = json.dumps({'results': [{'data': [{'meta': [{}]}]}],

--- a/graph_api/tests/test_property_relationship_service.py
+++ b/graph_api/tests/test_property_relationship_service.py
@@ -8,7 +8,7 @@ import json
 
 class TestRelationshipPostService(unittest.TestCase):
 
-    @mock.patch('relationship.relationship_service.requests')
+    @mock.patch('database_service.requests')
     def test_relationship_service_without_error(self, mock_requests):
         response = Response()
         response._content = json.dumps({'results': [
@@ -25,7 +25,7 @@ class TestRelationshipPostService(unittest.TestCase):
 
         self.assertEqual(result, RelationshipOut(id=5, properties=properties, errors=None))
 
-    @mock.patch('relationship.relationship_service.requests')
+    @mock.patch('database_service.requests')
     def test_relationship_service_with_error(self, mock_requests):
         response = Response()
         response._content = json.dumps({'results': [{'data': [{'meta': [{}]}]}],

--- a/graph_api/tests/test_relationship_service.py
+++ b/graph_api/tests/test_relationship_service.py
@@ -8,7 +8,7 @@ import json
 
 class TestRelationshipPostService(unittest.TestCase):
 
-    @mock.patch('relationship.relationship_service.requests')
+    @mock.patch('database_service.requests')
     def test_relationship_service_without_error(self, mock_requests):
         response = Response()
         response._content = json.dumps({'results': [
@@ -26,7 +26,7 @@ class TestRelationshipPostService(unittest.TestCase):
 
         self.assertEqual(result, RelationshipOut(start_node=1, end_node=2, name="test", id=5, errors=None))
 
-    @mock.patch('relationship.relationship_service.requests')
+    @mock.patch('database_service.requests')
     def test_relationship_service_with_error(self, mock_requests):
         response = Response()
         response._content = json.dumps({'results': [{'data': [{'meta': [{}]}]}],


### PR DESCRIPTION
Move all communication with the GraphDB to `DatabaseService`. I think this is more readable and will be easier to maintain. 