### PR TITLE
Set fixed FastAPI 0.87.0 version

### DIFF
--- a/ontology_api/requirements.txt
+++ b/ontology_api/requirements.txt
@@ -1,4 +1,4 @@
-fastapi
+fastapi==0.87.0
 uvicorn[standard]
 requests
 fastapi-utils


### PR DESCRIPTION
The test implementation for OntologyAPI does not work with the new version of FastAPI. Temporary fix until OntologyAPI branch is patched.